### PR TITLE
Add README in Portuguese

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,103 @@
+<h1 align="center">Memoteca</h1>
+<p align="center">
+  <img alt="Github top language" src="https://img.shields.io/github/languages/top/gsoaresdz/memoteca?color=56BEB8">
+  <img alt="Github language count" src="https://img.shields.io/github/languages/count/gsoaresdz/memoteca?color=56BEB8">
+  <img alt="Repository size" src="https://img.shields.io/github/repo-size/gsoaresdz/memoteca?color=56BEB8">
+</p>
+<p align="center">
+  <a href="#dart-sobre">Sobre</a> &#xa0; | &#xa0;
+  <a href="#sparkles-funcionalidades">Funcionalidades</a> &#xa0; | &#xa0;
+  <a href="#rocket-tecnologias">Tecnologias</a> &#xa0; | &#xa0;
+  <a href="#white_check_mark-requerimentos">Requerimentos</a> &#xa0; | &#xa0;
+  <a href="#checkered_flag-execucao">Execução</a> &#xa0; | &#xa0;
+  <a href="#memo-estrutura-dos-dados">Estrutura dos Dados</a> &#xa0; | &#xa0;
+  <a href="#memo-licenca">Licença</a> &#xa0; | &#xa0;
+  <a href="https://github.com/gsoaresdz" target="_blank">Autor</a>
+</p>
+<br>
+
+## **:dart: Sobre**
+
+Este repositório contém um projeto em Angular que funciona como um mural de pensamentos. Os usuários podem criar, visualizar, editar e remover pensamentos de forma simples.
+
+## **:sparkles: Funcionalidades**
+
+:heavy_check_mark: **Criar Pensamento**: cadastro de novos pensamentos
+
+:heavy_check_mark: **Listar Pensamentos**: exibição de todos os pensamentos cadastrados
+
+:heavy_check_mark: **Editar Pensamento**: atualização de pensamentos existentes
+
+:heavy_check_mark: **Excluir Pensamento**: remoção de pensamentos
+
+## **:rocket: Tecnologias**
+
+As seguintes ferramentas foram usadas neste projeto:
+
+- [Angular](https://angular.io/)
+- [TypeScript](https://www.typescriptlang.org/)
+- [JSON-Server](https://github.com/typicode/json-server)
+- [Node.js](https://nodejs.org/)
+
+## **:white_check_mark: Requerimentos**
+
+Antes de iniciar, você precisa ter [Node.js](https://nodejs.org/) e [npm](https://www.npmjs.com/) instalados.
+
+## **:checkered_flag: Execucao**
+
+### Clonando o Repositório
+
+```bash
+$ git clone https://github.com/gsoaresdz/memoteca.git
+```
+
+### Instalando Dependências
+
+Navegue até a pasta **memoteca** e instale as dependências do frontend:
+
+```bash
+$ npm install
+```
+
+Em seguida, acesse a pasta **memoteca/backend** e instale as dependências do backend:
+
+```bash
+$ npm install
+```
+
+### Iniciando o Backend
+
+Na pasta **memoteca/backend** execute:
+
+```bash
+$ npm start
+```
+
+### Iniciando o Frontend
+
+Na pasta **memoteca** execute:
+
+```bash
+$ npm start
+```
+
+A aplicação estará disponível em `http://localhost:4200/`.
+
+## **:memo: Estrutura dos Dados**
+
+Os pensamentos são compostos pelas seguintes propriedades:
+
+- `id`
+- `conteudo`
+- `autoria`
+- `modelo`
+
+## **:memo: Licenca**
+
+Este projeto está sob licença do MIT. Para mais detalhes, consulte o arquivo [LICENSE](LICENSE).
+
+Feito com :heart: por <a href="https://github.com/gsoaresdz" target="_blank">gsoaresdz</a>
+
+&#xa0;
+
+<a href="#top">De volta ao topo</a>


### PR DESCRIPTION
## Summary
- add project README in Portuguese with badges and usage instructions

## Testing
- `npm test` *(fails: `ng: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_686c543c58308325898d3dcaf7455d36